### PR TITLE
Implement list, remove, search, update and validate commands

### DIFF
--- a/src/commands/list/index.js
+++ b/src/commands/list/index.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function getIndexPath(isGlobal) {
+  const base = isGlobal ? os.homedir() : process.cwd();
+  return path.join(base, '.llm-cli', 'index.json');
+}
+
+function readIndex(indexPath) {
+  if (!fs.existsSync(indexPath)) return [];
+  return JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+}
+
+module.exports = (program) => {
+  program.command('list')
+    .description('List commands in the llm-cli index')
+    .option('-g, --global', 'Use global index')
+    .option('--include-dev', 'Include dev commands')
+    .action((options) => {
+      const index = readIndex(getIndexPath(options.global));
+      const cmds = index.filter(c => options.includeDev || !c.dev);
+      cmds.forEach(c => console.log(c.name));
+    });
+};

--- a/src/commands/remove/index.js
+++ b/src/commands/remove/index.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function getIndexPath(isGlobal) {
+  const base = isGlobal ? os.homedir() : process.cwd();
+  return path.join(base, '.llm-cli', 'index.json');
+}
+
+function readIndex(p) {
+  if (!fs.existsSync(p)) return [];
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function writeIndex(p, data) {
+  fs.writeFileSync(p, JSON.stringify(data, null, 2));
+}
+
+module.exports = (program) => {
+  program.command('remove <name>')
+    .description('Remove a command from the index')
+    .option('-g, --global', 'Use global index')
+    .action((name, options) => {
+      const indexPath = getIndexPath(options.global);
+      const index = readIndex(indexPath);
+      const filtered = index.filter(c => c.name !== name);
+      if (filtered.length === index.length) {
+        console.error(`Error: Command '${name}' not found.`);
+        process.exit(1);
+      }
+      writeIndex(indexPath, filtered);
+      console.log(`Command '${name}' removed successfully.`);
+    });
+};

--- a/src/commands/search/index.js
+++ b/src/commands/search/index.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function getIndexPath(isGlobal) {
+  const base = isGlobal ? os.homedir() : process.cwd();
+  return path.join(base, '.llm-cli', 'index.json');
+}
+
+function readIndex(p) {
+  if (!fs.existsSync(p)) return [];
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+module.exports = (program) => {
+  program.command('search <query>')
+    .description('Search commands in the index')
+    .option('-g, --global', 'Use global index')
+    .option('-t, --tag <tag>', 'Filter by tag')
+    .option('--include-dev', 'Include dev commands')
+    .action((query, options) => {
+      const terms = query.toLowerCase().split(/\s+/);
+      const index = readIndex(getIndexPath(options.global));
+      const results = index.filter(c => {
+        if (!options.includeDev && c.dev) return false;
+        if (options.tag && !(c.tags || []).includes(options.tag)) return false;
+        const text = `${c.name} ${c.description}`.toLowerCase();
+        return terms.every(t => text.includes(t));
+      });
+      results.forEach(c => console.log(c.name));
+    });
+};

--- a/src/commands/update/index.js
+++ b/src/commands/update/index.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function getIndexPath(isGlobal) {
+  const base = isGlobal ? os.homedir() : process.cwd();
+  return path.join(base, '.llm-cli', 'index.json');
+}
+
+function readIndex(p) {
+  if (!fs.existsSync(p)) return [];
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function writeIndex(p, data) {
+  fs.writeFileSync(p, JSON.stringify(data, null, 2));
+}
+
+module.exports = (program) => {
+  program.command('update <name>')
+    .description('Update a command in the index')
+    .option('-g, --global', 'Use global index')
+    .option('--new-name <name>', 'New command name')
+    .option('-t, --tag <tag...>', 'Set tags')
+    .option('--dev', 'Set dev flag true')
+    .option('--llm-help <cmd>', 'New llm help source')
+    .option('-d, --description <desc>', 'New description')
+    .action((name, options) => {
+      const indexPath = getIndexPath(options.global);
+      const index = readIndex(indexPath);
+      const cmd = index.find(c => c.name === name);
+      if (!cmd) {
+        console.error(`Error: Command '${name}' not found.`);
+        process.exit(1);
+      }
+      if (options.newName) {
+        if (index.some(c => c.name === options.newName)) {
+          console.error(`Error: Command with new name '${options.newName}' already exists.`);
+          process.exit(1);
+        }
+        cmd.name = options.newName;
+      }
+      if (options.tag) cmd.tags = options.tag;
+      if (options.dev !== undefined) cmd.dev = true;
+      if (options.llmHelp) cmd.llmHelpSource = options.llmHelp;
+      if (options.description) cmd.description = options.description;
+      writeIndex(indexPath, index);
+      console.log(`Command '${cmd.name}' updated successfully.`);
+    });
+};

--- a/src/commands/validate/index.js
+++ b/src/commands/validate/index.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function getIndexPath(isGlobal) {
+  const base = isGlobal ? os.homedir() : process.cwd();
+  return path.join(base, '.llm-cli', 'index.json');
+}
+
+function readIndex(p) {
+  if (!fs.existsSync(p)) return [];
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+module.exports = (program) => {
+  program.command('validate')
+    .description('Validate the llm-cli index')
+    .option('-g, --global', 'Use global index')
+    .action((options) => {
+      const indexPath = getIndexPath(options.global);
+      try {
+        const index = readIndex(indexPath);
+        const seen = new Set();
+        index.forEach(cmd => {
+          if (!cmd.name || !cmd.url) throw new Error('Missing required field');
+          if (seen.has(cmd.name)) throw new Error('Duplicate names');
+          seen.add(cmd.name);
+          const filePath = cmd.url.replace('file://', '');
+          if (!fs.existsSync(filePath)) throw new Error(`Missing file ${cmd.name}`);
+        });
+        console.log('Index is valid.');
+      } catch (e) {
+        console.error(`Validation error: ${e.message}`);
+        process.exit(1);
+      }
+    });
+};

--- a/src/index.js
+++ b/src/index.js
@@ -10,5 +10,10 @@ program
 // Load commands
 require('./commands/init')(program);
 require('./commands/add')(program);
+require('./commands/list')(program);
+require('./commands/remove')(program);
+require('./commands/search')(program);
+require('./commands/update')(program);
+require('./commands/validate')(program);
 
 program.parse(process.argv);

--- a/tests/commands/list.test.js
+++ b/tests/commands/list.test.js
@@ -1,0 +1,49 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const localDir = path.join(process.cwd(), '.llm-cli');
+const localIndex = path.join(localDir, 'index.json');
+const globalDir = path.join(os.homedir(), '.llm-cli');
+const globalIndex = path.join(globalDir, 'index.json');
+
+const writeIndex = (isGlobal, data) => {
+  const dir = isGlobal ? globalDir : localDir;
+  const indexPath = isGlobal ? globalIndex : localIndex;
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(indexPath, JSON.stringify(data, null, 2));
+};
+
+const cleanup = () => {
+  if (fs.existsSync(localDir)) fs.rmSync(localDir, { recursive: true, force: true });
+  if (fs.existsSync(globalDir)) fs.rmSync(globalDir, { recursive: true, force: true });
+};
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+describe('llm-cli list', () => {
+  test('lists local commands excluding dev', () => {
+    writeIndex(false, [
+      { name: 'command1', url: 'file:///tmp/c1', dev: false },
+      { name: 'command2', url: 'file:///tmp/c2', dev: true }
+    ]);
+    const out = execSync('node src/index.js list', { encoding: 'utf8' });
+    expect(out).toContain('command1');
+    expect(out).not.toContain('command2');
+  });
+
+  test('lists global commands', () => {
+    writeIndex(true, [{ name: 'global-command1', url: 'file:///tmp/g1', dev: false }]);
+    const out = execSync('node src/index.js list --global', { encoding: 'utf8' });
+    expect(out).toContain('global-command1');
+  });
+
+  test('lists dev commands when requested', () => {
+    writeIndex(false, [{ name: 'devcmd', url: 'file:///tmp/d', dev: true }]);
+    const out = execSync('node src/index.js list --include-dev', { encoding: 'utf8' });
+    expect(out).toContain('devcmd');
+  });
+});

--- a/tests/commands/remove.test.js
+++ b/tests/commands/remove.test.js
@@ -1,0 +1,43 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const localDir = path.join(process.cwd(), '.llm-cli');
+const localIndex = path.join(localDir, 'index.json');
+const globalDir = path.join(os.homedir(), '.llm-cli');
+const globalIndex = path.join(globalDir, 'index.json');
+
+const writeIndex = (isGlobal, data) => {
+  const dir = isGlobal ? globalDir : localDir;
+  const indexPath = isGlobal ? globalIndex : localIndex;
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(indexPath, JSON.stringify(data, null, 2));
+};
+
+const cleanup = () => {
+  if (fs.existsSync(localDir)) fs.rmSync(localDir, { recursive: true, force: true });
+  if (fs.existsSync(globalDir)) fs.rmSync(globalDir, { recursive: true, force: true });
+};
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+describe('llm-cli remove', () => {
+  test('removes an existing local command', () => {
+    writeIndex(false, [{ name: 'my-script', url: 'file:///tmp/s' }]);
+    execSync('node src/index.js remove my-script');
+    const index = JSON.parse(fs.readFileSync(localIndex, 'utf8'));
+    expect(index.length).toBe(0);
+  });
+
+  test('fails when command does not exist', () => {
+    writeIndex(false, []);
+    try {
+      execSync('node src/index.js remove missing', { stdio: 'pipe' });
+    } catch (e) {
+      expect(e.stderr.toString()).toContain("Error: Command 'missing' not found.");
+    }
+  });
+});

--- a/tests/commands/search.test.js
+++ b/tests/commands/search.test.js
@@ -1,0 +1,52 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const localDir = path.join(process.cwd(), '.llm-cli');
+const localIndex = path.join(localDir, 'index.json');
+
+const cleanup = () => {
+  if (fs.existsSync(localDir)) fs.rmSync(localDir, { recursive: true, force: true });
+};
+
+const writeIndex = (data) => {
+  fs.mkdirSync(localDir, { recursive: true });
+  fs.writeFileSync(localIndex, JSON.stringify(data, null, 2));
+};
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+describe('llm-cli search', () => {
+  test('search by keyword', () => {
+    writeIndex([
+      { name: 'analyze-code', description: 'Analyzes source code', url: 'file:///a' },
+      { name: 'build-project', url: 'file:///b' }
+    ]);
+    const out = execSync('node src/index.js search code', { encoding: 'utf8' });
+    expect(out).toContain('analyze-code');
+    expect(out).not.toContain('build-project');
+  });
+
+  test('search by tag', () => {
+    writeIndex([
+      { name: 'typescript-linter', tags: ['typescript', 'lint'], url: 'file:///t' },
+      { name: 'python-formatter', tags: ['python', 'format'], url: 'file:///p' }
+    ]);
+    const out = execSync('node src/index.js search --tag lint lint', { encoding: 'utf8' });
+    expect(out).toContain('typescript-linter');
+    expect(out).not.toContain('python-formatter');
+  });
+
+  test('include dev commands', () => {
+    writeIndex([
+      { name: 'prod-tool', dev: false, url: 'file:///p' },
+      { name: 'dev-tool', dev: true, url: 'file:///d' }
+    ]);
+    const out = execSync('node src/index.js search --include-dev tool', { encoding: 'utf8' });
+    expect(out).toContain('prod-tool');
+    expect(out).toContain('dev-tool');
+  });
+});

--- a/tests/commands/update.test.js
+++ b/tests/commands/update.test.js
@@ -1,0 +1,45 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const localDir = path.join(process.cwd(), '.llm-cli');
+const localIndex = path.join(localDir, 'index.json');
+
+const cleanup = () => {
+  if (fs.existsSync(localDir)) fs.rmSync(localDir, { recursive: true, force: true });
+};
+
+const writeIndex = (data) => {
+  fs.mkdirSync(localDir, { recursive: true });
+  fs.writeFileSync(localIndex, JSON.stringify(data, null, 2));
+};
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+describe('llm-cli update', () => {
+  test('updates command name', () => {
+    writeIndex([{ name: 'old-name', url: 'file:///a' }]);
+    execSync('node src/index.js update old-name --new-name new-name');
+    const idx = JSON.parse(fs.readFileSync(localIndex, 'utf8'));
+    expect(idx[0].name).toBe('new-name');
+  });
+
+  test('updates tags', () => {
+    writeIndex([{ name: 'my-script', tags: ['t1'], url: 'file:///b' }]);
+    execSync('node src/index.js update my-script -t tagA -t tagB');
+    const idx = JSON.parse(fs.readFileSync(localIndex, 'utf8'));
+    expect(idx[0].tags).toEqual(['tagA', 'tagB']);
+  });
+
+  test('fails for non existent command', () => {
+    writeIndex([]);
+    try {
+      execSync('node src/index.js update no-cmd --new-name x', { stdio: 'pipe' });
+    } catch (e) {
+      expect(e.stderr.toString()).toContain("Error: Command 'no-cmd' not found.");
+    }
+  });
+});

--- a/tests/commands/validate.test.js
+++ b/tests/commands/validate.test.js
@@ -1,0 +1,37 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const localDir = path.join(process.cwd(), '.llm-cli');
+const localIndex = path.join(localDir, 'index.json');
+
+const cleanup = () => {
+  if (fs.existsSync(localDir)) fs.rmSync(localDir, { recursive: true, force: true });
+};
+
+const writeIndex = (data) => {
+  fs.mkdirSync(localDir, { recursive: true });
+  fs.writeFileSync(localIndex, JSON.stringify(data, null, 2));
+};
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+describe('llm-cli validate', () => {
+  test('reports success for valid index', () => {
+    writeIndex([{ name: 'cmd', url: 'file:///tmp/cmd' }]);
+    const out = execSync('node src/index.js validate', { encoding: 'utf8' });
+    expect(out).toContain('Index is valid.');
+  });
+
+  test('fails for missing file', () => {
+    writeIndex([{ name: 'bad', url: 'file:///no/file' }]);
+    try {
+      execSync('node src/index.js validate', { stdio: 'pipe' });
+    } catch (e) {
+      expect(e.stderr.toString()).toContain('Missing file bad');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add missing command modules: list, remove, search, update and validate
- load these new commands in the CLI entry point
- write tests for each new command

## Testing
- `npx vitest run` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6866756cdcf8832d9d5131b55f4af537