### PR TITLE
Fix docs test timeout

### DIFF
--- a/tests/docs.test.js
+++ b/tests/docs.test.js
@@ -21,7 +21,7 @@ describe('Documentation build', () => {
   beforeAll(() => {
     cleanDist(); // Clean before building to ensure a fresh build
     buildDocs();
-  });
+  }, 30000);
 
   afterAll(() => {
     cleanDist();


### PR DESCRIPTION
## Summary
- extend `beforeAll` timeout so `vitepress build` doesn't hit 'Hook timed out'

## Testing
- `npx vitest run tests/docs.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6868ab3d0060832d9fe78ddb510e912a