### PR TITLE
Refactor tests to reduce file length

### DIFF
--- a/tests/commands/add/config-errors.test.js
+++ b/tests/commands/add/config-errors.test.js
@@ -1,0 +1,60 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { cleanup, initCliIndex, createDummyScript } from '../../test-utils.js';
+
+describe('llm-cli add command from configuration file errors', () => {
+  const configFilePath = path.join(process.cwd(), 'commands.json');
+
+  beforeEach(() => {
+    initCliIndex(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (fs.existsSync(configFilePath)) {
+      fs.unlinkSync(configFilePath);
+    }
+  });
+
+  test('should display an error for missing required fields in config', () => {
+    const config = [{ "url": "file:///path/to/script.js" }];
+    fs.writeFileSync(configFilePath, JSON.stringify(config, null, 2));
+    try {
+      execSync(`node src/index.js add --config ${configFilePath}`);
+      expect.fail('Command did not throw an error.');
+    } catch (error) {
+      expect(error.stderr.toString()).toContain('Error: Command from configuration is missing required fields');
+    }
+  });
+
+  test('should display an error for duplicate names in config', () => {
+    const scriptPath = createDummyScript('script.js', 'console.log("description")');
+    const config = [
+      { name: 'duplicate', url: `file://${scriptPath}`, description: 'desc1' },
+      { name: 'duplicate', url: `file://${scriptPath}`, description: 'desc2' }
+    ];
+    fs.writeFileSync(configFilePath, JSON.stringify(config, null, 2));
+    try {
+      execSync(`node src/index.js add --config ${configFilePath}`);
+      expect.fail('Command did not throw an error.');
+    } catch (error) {
+      expect(error.stderr.toString()).toContain('Error: Duplicate command name found in configuration: duplicate');
+    }
+  });
+
+  test('should display an error for existing names in index', () => {
+    const script1Path = createDummyScript('script1.js', 'console.log("desc1")');
+    execSync(`node src/index.js add ${script1Path} --name existing-command`);
+    const script2Path = createDummyScript('script2.js', 'console.log("desc2")');
+    const config = [{ name: 'existing-command', url: `file://${script2Path}`, description: 'desc2' }];
+    fs.writeFileSync(configFilePath, JSON.stringify(config, null, 2));
+    try {
+      execSync(`node src/index.js add --config ${configFilePath}`);
+      expect.fail('Command did not throw an error.');
+    } catch (error) {
+      expect(error.stderr.toString()).toContain("Error: Command with name 'existing-command' already exists in the index.");
+    }
+  });
+});

--- a/tests/commands/add/config.test.js
+++ b/tests/commands/add/config.test.js
@@ -64,43 +64,4 @@ describe('llm-cli add command from configuration file', () => {
     }
   });
 
-  test('should display an error for missing required fields in config', () => {
-    const config = [{ "url": "file:///path/to/script.js" }]; // Missing name and description
-    fs.writeFileSync(configFilePath, JSON.stringify(config, null, 2));
-    try {
-      execSync(`node src/index.js add --config ${configFilePath}`);
-      expect.fail('Command did not throw an error.');
-    } catch (error) {
-      expect(error.stderr.toString()).toContain("Error: Command from configuration is missing required fields");
-    }
-  });
-
-  test('should display an error for duplicate names in config', () => {
-    const scriptPath = createDummyScript('script.js', 'console.log("description")');
-    const config = [
-      { "name": "duplicate", "url": `file://${scriptPath}`, "description": "desc1" },
-      { "name": "duplicate", "url": `file://${scriptPath}`, "description": "desc2" }
-    ];
-    fs.writeFileSync(configFilePath, JSON.stringify(config, null, 2));
-    try {
-      execSync(`node src/index.js add --config ${configFilePath}`);
-      expect.fail('Command did not throw an error.');
-    } catch (error) {
-      expect(error.stderr.toString()).toContain("Error: Duplicate command name found in configuration: duplicate");
-    }
-  });
-
-  test('should display an error for existing names in index', () => {
-    const script1Path = createDummyScript('script1.js', 'console.log("desc1")');
-    execSync(`node src/index.js add ${script1Path} --name existing-command`);
-    const script2Path = createDummyScript('script2.js', 'console.log("desc2")');
-    const config = [{ "name": "existing-command", "url": `file://${script2Path}`, "description": "desc2" }];
-    fs.writeFileSync(configFilePath, JSON.stringify(config, null, 2));
-    try {
-      execSync(`node src/index.js add --config ${configFilePath}`);
-      expect.fail('Command did not throw an error.');
-    } catch (error) {
-      expect(error.stderr.toString()).toContain("Error: Command with name 'existing-command' already exists in the index.");
-    }
-  });
 });

--- a/tests/commands/add/edge.test.js
+++ b/tests/commands/add/edge.test.js
@@ -1,0 +1,27 @@
+import { describe, test, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import { cleanup, initCliIndex, createDummyScript } from '../../test-utils.js';
+
+describe('llm-cli add command edge cases', () => {
+  beforeEach(() => {
+    initCliIndex(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should add a command with an install command', () => {
+    cleanup();
+    initCliIndex(false);
+    //TODO: Ne pas utiliser de script local ici
+    // Utiliser `npm i -g vitepress` pour tester l\'installation
+  });
+
+  test('should NOT error if command does not respond to help', () => {
+    cleanup();
+    initCliIndex(false);
+    const scriptPath = createDummyScript('non-responsive-script.js', 'process.exit(1);');
+    // TODO: This should not throw an error, but we need to ensure it does not crash
+  });
+});

--- a/tests/commands/add/index.test.js
+++ b/tests/commands/add/index.test.js
@@ -74,22 +74,6 @@ describe('llm-cli add command', () => {
     expect(indexContent[0].description).toBe('My custom description.');
   });
 
-  // Scenario: Add a command with an install command
-  test('should add a command with an install command', () => {
-    cleanup();
-    initCliIndex(false);
-    //TODO: Ne pas utiliser de script local ici
-    // Utiliser `npm i -g vitepress` pour tester l'installation
-  });
-
-  // Scenario: Attempt to add a command that does not respond to --help
-  test('should NOT error if command does not respond to help', () => {
-    cleanup();
-    initCliIndex(false); // Initialize index explicitly for this test
-    const scriptPath = createDummyScript('non-responsive-script.js', 'process.exit(1);');
-    // TODO: This should not throw an error, but we need to ensure it does not crash
-  });
-
   // Scenario: Attempt to add a command with a duplicate name
   test('should prevent adding command with duplicate name', () => {
     cleanup();


### PR DESCRIPTION
## Summary
- keep each `add` command test file under 100 lines
- move long scenarios into separate files

## Testing
- `npm run test:ci` *(fails: No "default" export is defined on the "fs" mock)*

------
https://chatgpt.com/codex/tasks/task_e_6868ab4e791c832d813aa89948e66dfe