### PR TITLE
Fix fs mocks in process tests

### DIFF
--- a/src/commands/add/processes/processConfigFile.process.test.js
+++ b/src/commands/add/processes/processConfigFile.process.test.js
@@ -8,21 +8,17 @@ import { inferTagsFromExtension } from './inferTagsFromExtension.process.js';
 // Mock external dependencies
 
 
-vi.mock('fs', async () => {
-  const actual = await vi.importActual('fs');
-  return {
-    ...actual,
-    existsSync: vi.fn(),
-    readFileSync: vi.fn(),
-  };
+vi.mock('fs', () => {
+  const existsSync = vi.fn();
+  const readFileSync = vi.fn();
+  return { existsSync, readFileSync, default: { existsSync, readFileSync } };
 });
 
-vi.mock('path', async () => {
-  const actual = await vi.importActual('path');
-  return {
-    ...actual,
-    extname: vi.fn(),
-  };
+vi.mock('path', () => {
+  const extname = vi.fn();
+  const resolve = vi.fn();
+  const dirname = vi.fn();
+  return { extname, resolve, dirname, default: { extname, resolve, dirname } };
 });
 
 vi.mock('./getCommandDescription.process.js', () => ({

--- a/src/commands/add/processes/processSingleCommand.process.test.js
+++ b/src/commands/add/processes/processSingleCommand.process.test.js
@@ -8,16 +8,18 @@ import { inferTagsFromExtension } from './inferTagsFromExtension.process.js';
 // Mock external dependencies
 
 
-vi.mock('fs', () => ({
-  existsSync: vi.fn(),
-  lstatSync: vi.fn(),
-}));
+vi.mock('fs', () => {
+  const existsSync = vi.fn();
+  const lstatSync = vi.fn();
+  return { existsSync, lstatSync, default: { existsSync, lstatSync } };
+});
 
-vi.mock('path', () => ({
-  resolve: vi.fn(),
-  dirname: vi.fn(),
-  extname: vi.fn(),
-}));
+vi.mock('path', () => {
+  const resolve = vi.fn(p => p);
+  const dirname = vi.fn(p => p.split('/').slice(0, -1).join('/'));
+  const extname = vi.fn();
+  return { resolve, dirname, extname, default: { resolve, dirname, extname } };
+});
 
 vi.mock('./getCommandDescription.process.js', () => ({
   getCommandDescription: vi.fn(),


### PR DESCRIPTION
## Summary
- ensure fs mocks provide a `default` export
- update associated path mocks

## Testing
- `npm run test:ci` *(fails: some tests reported failing)*

------
https://chatgpt.com/codex/tasks/task_e_6868acbd9190832d84881edb51a7a0ec