### PR TITLE
Fix CI Rollup install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci --ignore-scripts
+      - run: npm ci
       - run: npm run test:ci
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary
- build docs without ignoring postinstall scripts in CI

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_6868b2009bb0832da28864132bb52f7b